### PR TITLE
Fix UIKit availability and LinuxMain

### DIFF
--- a/Sources/LoremIpsum/UIKit+LoremIpsum.swift
+++ b/Sources/LoremIpsum/UIKit+LoremIpsum.swift
@@ -24,7 +24,7 @@ public protocol Loremable {
     func lorem()
 }
 
-#if !os(macOS)
+#if canImport(UIKit)
 import UIKit
 
 extension UILabel: Loremable {

--- a/Tests/LinuxMain.swift
+++ b/Tests/LinuxMain.swift
@@ -1,7 +1,7 @@
 import XCTest
 
-import LoremIpsum_SwiftTests
+import LoremIpsum_Tests
 
 var tests = [XCTestCaseEntry]()
-tests += LoremIpsum_SwiftTests.allTests()
+tests += LoremIpsum_Tests.allTests()
 XCTMain(tests)


### PR DESCRIPTION
## Summary
- guard UIKit imports with `canImport(UIKit)` to support Linux builds
- correct LinuxMain to use sanitized test module name

## Testing
- `swift test`

------
https://chatgpt.com/codex/tasks/task_e_688478489e1c832aa0a3536bc63ab434