### PR TITLE
Add test for longest word length consistency

### DIFF
--- a/Tests/LoremIpsum-Tests/LoremIpsum_SwiftTests.swift
+++ b/Tests/LoremIpsum-Tests/LoremIpsum_SwiftTests.swift
@@ -10,7 +10,16 @@ final class LoremIpsum_SwiftTests: XCTestCase {
         XCTAssertTrue(paragraph.starts(with: "Lorem ipsum"))
     }
 
+    func testLongestWordLengthMatchesDistributionMax() {
+        let lipsum = String.LoremIpsum()
+        let longest = lipsum.longestWordLength
+        let distMax = lipsum.wordsLengthDistribution().keys.max()
+        XCTAssertNotNil(distMax)
+        XCTAssertEqual(longest, distMax!)
+    }
+
     static var allTests = [
         ("testExample", testExample),
+        ("testLongestWordLengthMatchesDistributionMax", testLongestWordLengthMatchesDistributionMax),
     ]
 }


### PR DESCRIPTION
## Summary
- add test verifying `longestWordLength` equals the maximum key from `wordsLengthDistribution`
- register the new test in `allTests`

## Testing
- `swift test`

------
https://chatgpt.com/codex/tasks/task_e_688479c44150832ab1ac9d811bd40962