### PR TITLE
Fix README typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # LoremIpsum-Swift
 LoremIpsum String generator for Swift
 
-## Instalation
+## Installation
 
 ### Swift Package Manager
-Add the following package to your dependecies: `https://github.com/owlcoding/LoremIpsum-Swift/`
+Add the following package to your dependencies: `https://github.com/owlcoding/LoremIpsum-Swift/`
 
 ## How does it work? 
 The main API is exposed as static method on `String` extension:


### PR DESCRIPTION
## Summary
- fix heading spelling in README
- correct dependencies typo

## Testing
- `swift test`

------
https://chatgpt.com/codex/tasks/task_e_688479a5b6a8832a8839d16de764ff86